### PR TITLE
boot args redefine error solved

### DIFF
--- a/u-boot/include/configs/sun8i.h
+++ b/u-boot/include/configs/sun8i.h
@@ -27,13 +27,6 @@
 	#define CONFIG_SUNXI_USB_PHYS	2
 #endif
 
-#define CONFIG_BOOTCOMMAND   "setenv bootm_boot_mode sec; " \
-                            "load mmc 0:1 0x41000000 zImage; "  \
-                            "load mmc 0:1 0x41800000 sun8i-v3s-licheepi-zero-dock.dtb; " \
-                            "bootz 0x41000000 - 0x41800000;"
-
-#define CONFIG_BOOTARGS      "console=ttyS0,115200 panic=5 rootwait root=/dev/mmcblk0p2 earlyprintk rw  vt.global_cursor_default=0"
-
 
 /*
  * Include common sunxi configuration where most the settings are


### PR DESCRIPTION
leave the boot command outside in boot.cmd so the system can skip command build from u-boot